### PR TITLE
French language little fix on adblock.properties.

### DIFF
--- a/resource/extension/default/1.0_0/locales/fr-FR/adblock.properties
+++ b/resource/extension/default/1.0_0/locales/fr-FR/adblock.properties
@@ -1,9 +1,9 @@
-adblockTitle=Bloquage de publicités
-adblock=Bloquage de publicités
-lastUpdateCheckDateLabel=Dernière vérification de mise à jour :
-lastCheckETagLabel=Dernière vérification ETag :
-blockedCountLabel=Compteur de publicités bloquées :
+adblockTitle=Blocage de publicités
+adblock=Blocage de publicités
+lastUpdateCheckDateLabel=Dernière vérification de mise à jour :
+lastCheckETagLabel=Dernière vérification ETag :
+blockedCountLabel=Compteur de publicités bloquées :
 additionalFilterLists=Listes de filtres supplémentaires
 customFilters=Filtres personnalisés
 customFilterDescription=Un par ligne, un filtre est décrit dans la syntaxe de filtre de Adblock Plus
-adblockTooManyListsWarning=Attention : Activer trop de listes dégradera les performances
+adblockTooManyListsWarning=Attention : Activer trop de listes dégradera les performances


### PR DESCRIPTION
Here's a couple of little fix for this file.
 - I've changed the word "Bloquage" in adblockTitle & adblock as this word has an incorrect orthography. It should be "Blocage".

> 
> blocage m (plural blocages)
> 
> 1 block (e.g. of traffic)
> 2 block (act of physically blocking)
> 3 block (obstruction)
> 4 (Internet) block, blocking
> 5 blockage
> 6 locking (of brakes)

https://en.wiktionary.org/wiki/blocage

> 
> Blocage
> ブロッキング
> 
> IPA: /blɔk.aʒ; Gender: masculine; Type: noun;
> 
> 1 阻止 {	Verbal; Noun, noun }
> 2 ブロッキング {	noun }
> 3 渋滞 {	Noun; Verbal }

https://glosbe.com/fr/ja/Blocage

 - I've added an insecable space before the: in lastUpdateCheckDateLabel, lastCheckETagLabel, blockedCountLabel and adblockTooManyListsWarning.
It's, however, a bit pointless, as almost invisible, but that's still something.

> U+202F   narrow no-break space (HTML: &#8239; NNBSP)（狭いノーブレークスペース） - Unicode 3.0でモンゴル語のために導入された。単語の境界を示すことなく、接尾辞を語幹から切り離すのに使う。また、フランス語（" ; ? ! » › " の前と " « ‹ " の後。今日では " : " の前も）やロシア語（" — "の前）の約物の前後、ドイツ語の複数語からなる省略語 (z. B., d. h., v. l. n. r.) においても使用される。モンゴル語で使用する場合は通常のスペースの3分の1の幅、他の言語では70%の幅だが、いくつかのフォントではシンスペース（英語版） (U+2009) と同じになっている。

https://ja.wikipedia.org/wiki/ノーブレークスペース